### PR TITLE
Implement ban as drop rather than close

### DIFF
--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -158,11 +158,12 @@ func (ws *webseedPeer) connectionFlags() string {
 	return "WS"
 }
 
-// Maybe this should drop all existing connections, or something like that.
-func (ws *webseedPeer) drop() {}
+func (ws *webseedPeer) drop() {
+	ws.peer.cancelAllRequests()
+}
 
 func (cn *webseedPeer) ban() {
-	cn.peer.close()
+	cn.peer.drop()
 }
 
 func (ws *webseedPeer) handleUpdateRequests() {


### PR DESCRIPTION
Change ban handling for webseed peers to be closer to torrent peers by calling drop on ban rather than close.  

Drop is implemented by closing all existing web requests (the equivalent of closing and re-opening the connection).