### PR TITLE
Added max capacity request buffer pool

### DIFF
--- a/client.go
+++ b/client.go
@@ -171,7 +171,7 @@ func (cl *Client) WriteStatus(_w io.Writer) {
 				fmt.Fprintf(
 					w,
 					"%f%% of %d bytes (%s)",
-					100*(1-float64(t.bytesLeft(false))/float64(t.info.TotalLength())),
+					100*(1-float64(t.bytesLeft(false, false))/float64(t.info.TotalLength())),
 					t.length(false),
 					humanize.Bytes(uint64(t.length(false))))
 			} else {

--- a/client.go
+++ b/client.go
@@ -1206,7 +1206,7 @@ func (pc *PeerConn) sendInitialMessages(lockTorrent bool) {
 	}
 
 	if pc.fastEnabled() {
-		if t.haveAllPieces(lockTorrent) {
+		if t.haveAllPieces(lockTorrent, true) {
 			pc.write(pp.Message{Type: pp.HaveAll}, true)
 			pc.sentHaves.AddRange(0, bitmap.BitRange(pc.t.NumPieces()))
 			return
@@ -1533,7 +1533,7 @@ func (cl *Client) allTorrentsCompleted() bool {
 		if !t.haveInfo(true) {
 			return false
 		}
-		if !t.haveAllPieces(true) {
+		if !t.haveAllPieces(true, true) {
 			return false
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -158,6 +158,8 @@ func (cl *Client) WriteStatus(_w io.Writer) {
 		func() {
 			t.mu.RLock()
 			defer t.mu.RUnlock()
+			t.imu.RLock()
+			defer t.imu.RUnlock()
 
 			if t.name(false) == "" {
 				fmt.Fprint(w, "<unknown name>")
@@ -170,8 +172,8 @@ func (cl *Client) WriteStatus(_w io.Writer) {
 					w,
 					"%f%% of %d bytes (%s)",
 					100*(1-float64(t.bytesLeft(false))/float64(t.info.TotalLength())),
-					t.length(),
-					humanize.Bytes(uint64(t.length())))
+					t.length(false),
+					humanize.Bytes(uint64(t.length(false))))
 			} else {
 				w.WriteString("<missing metainfo>")
 			}

--- a/client_test.go
+++ b/client_test.go
@@ -96,7 +96,7 @@ func TestTorrentInitialState(t *testing.T) {
 	require.Len(t, tor.pieces, 3)
 	tor.pendAllChunkSpecs(0, true)
 	tor.cl.lock()
-	assert.EqualValues(t, 3, tor.pieceNumPendingChunks(0, true))
+	assert.EqualValues(t, 3, tor.pieceNumPendingChunks(&tor.pieces[0], true))
 	tor.cl.unlock()
 	assert.EqualValues(t, ChunkSpec{4, 1}, chunkIndexSpec(2, tor.pieceLength(0), tor.chunkSize))
 }

--- a/client_test.go
+++ b/client_test.go
@@ -98,7 +98,7 @@ func TestTorrentInitialState(t *testing.T) {
 	tor.cl.lock()
 	assert.EqualValues(t, 3, tor.pieceNumPendingChunks(&tor.pieces[0], true))
 	tor.cl.unlock()
-	assert.EqualValues(t, ChunkSpec{4, 1}, chunkIndexSpec(2, tor.pieceLength(0), tor.chunkSize))
+	assert.EqualValues(t, ChunkSpec{4, 1}, chunkIndexSpec(2, tor.pieceLength(0, true), tor.chunkSize))
 }
 
 func TestReducedDialTimeout(t *testing.T) {
@@ -519,7 +519,7 @@ func testDownloadCancel(t *testing.T, ps testDownloadCancelParams) {
 	defer psc.Close()
 
 	leecherGreeting.cl.lock()
-	leecherGreeting.DownloadPieces(0, leecherGreeting.numPieces())
+	leecherGreeting.DownloadPieces(0, leecherGreeting.numPieces(true))
 	if ps.Cancel {
 		leecherGreeting.CancelPieces(0, leecherGreeting.NumPieces())
 	}

--- a/file.go
+++ b/file.go
@@ -113,7 +113,7 @@ func fileBytesLeft(
 func (f *File) bytesLeft() (left int64) {
 	f.t.mu.RLock()
 	defer f.t.mu.RUnlock()
-	return fileBytesLeft(int64(f.t.usualPieceSize()), f.BeginPieceIndex(), f.EndPieceIndex(), f.offset, f.length, &f.t._completedPieces, func(pieceIndex int) int64 {
+	return fileBytesLeft(int64(f.t.usualPieceSize(true)), f.BeginPieceIndex(), f.EndPieceIndex(), f.offset, f.length, &f.t._completedPieces, func(pieceIndex int) int64 {
 		return int64(f.t.piece(pieceIndex, false).numDirtyBytes(false))
 	})
 }
@@ -134,7 +134,7 @@ type FilePieceState struct {
 func (f *File) State() (ret []FilePieceState) {
 	f.t.mu.RLock()
 	defer f.t.mu.RUnlock()
-	pieceSize := int64(f.t.usualPieceSize())
+	pieceSize := int64(f.t.usualPieceSize(true))
 	off := f.offset % pieceSize
 	remaining := f.length
 	for i := pieceIndex(f.offset / pieceSize); ; i++ {
@@ -193,16 +193,18 @@ func (f *File) Priority() (prio piecePriority) {
 
 // Returns the index of the first piece containing data for the file.
 func (f *File) BeginPieceIndex() int {
-	if f.t.usualPieceSize() == 0 {
+	usualPieceSize := int64(f.t.usualPieceSize(true))
+	if usualPieceSize == 0 {
 		return 0
 	}
-	return pieceIndex(f.offset / int64(f.t.usualPieceSize()))
+	return pieceIndex(f.offset / usualPieceSize)
 }
 
 // Returns the index of the piece after the last one containing data for the file.
 func (f *File) EndPieceIndex() int {
-	if f.t.usualPieceSize() == 0 {
+	usualPieceSize := int64(f.t.usualPieceSize(true))
+	if usualPieceSize == 0 {
 		return 0
 	}
-	return pieceIndex((f.offset + f.length + int64(f.t.usualPieceSize()) - 1) / int64(f.t.usualPieceSize()))
+	return pieceIndex((f.offset + f.length + usualPieceSize - 1) / usualPieceSize)
 }

--- a/file.go
+++ b/file.go
@@ -114,7 +114,7 @@ func (f *File) bytesLeft() (left int64) {
 	f.t.mu.RLock()
 	defer f.t.mu.RUnlock()
 	return fileBytesLeft(int64(f.t.usualPieceSize(true)), f.BeginPieceIndex(), f.EndPieceIndex(), f.offset, f.length, &f.t._completedPieces, func(pieceIndex int) int64 {
-		return int64(f.t.piece(pieceIndex, false).numDirtyBytes(false))
+		return int64(f.t.piece(pieceIndex, false).numDirtyBytes(false,true))
 	})
 }
 

--- a/peer-impl.go
+++ b/peer-impl.go
@@ -38,7 +38,7 @@ type peerImpl interface {
 	// guess at how many pieces are in a torrent, and assume they have all pieces based on them
 	// having sent haves for everything, but we don't know for sure. But if they send a have-all
 	// message, then it's clear that they do.
-	peerHasAllPieces(lock bool, lockTorrent bool) (all, known bool)
+	peerHasAllPieces(lock bool) (all, known bool)
 	peerPieces(lock bool) *roaring.Bitmap
 
 	nominalMaxRequests(lock bool, lockTorrent bool) maxRequests

--- a/peer-impl.go
+++ b/peer-impl.go
@@ -38,7 +38,7 @@ type peerImpl interface {
 	// guess at how many pieces are in a torrent, and assume they have all pieces based on them
 	// having sent haves for everything, but we don't know for sure. But if they send a have-all
 	// message, then it's clear that they do.
-	peerHasAllPieces(lock bool) (all, known bool)
+	peerHasAllPieces(lock bool, lockTorrentInfo bool) (all, known bool)
 	peerPieces(lock bool) *roaring.Bitmap
 
 	nominalMaxRequests(lock bool, lockTorrent bool) maxRequests

--- a/peer.go
+++ b/peer.go
@@ -28,7 +28,7 @@ type (
 	Peer struct {
 		// First to ensure 64-bit alignment for atomics. See #262.
 		_stats ConnStats
-		mu     sync.RWMutex
+		mu     mu //sync.RWMutex
 
 		t *Torrent
 

--- a/peer.go
+++ b/peer.go
@@ -231,7 +231,7 @@ func (cn *Peer) bestPeerNumPieces(lock bool) pieceIndex {
 func (cn *Peer) completedString(lock bool) string {
 	have := pieceIndex(cn.peerPieces(lock).GetCardinality())
 	best := cn.bestPeerNumPieces(lock)
-	if all, _ := cn.peerHasAllPieces(lock); all {
+	if all, _ := cn.peerHasAllPieces(lock, true); all {
 		have = best
 	}
 	return fmt.Sprintf("%d/%d", have, best)
@@ -405,7 +405,7 @@ func (cn *Peer) peerHasPiece(piece pieceIndex, lock bool, lockTorrent bool) bool
 		defer cn.mu.RUnlock()
 	}
 
-	if all, known := cn.peerHasAllPieces(false); all && known {
+	if all, known := cn.peerHasAllPieces(false, true); all && known {
 		return true
 	}
 
@@ -926,7 +926,7 @@ func (c *Peer) peerHasWantedPieces(lock bool, lockTorrent bool) bool {
 		defer c.mu.RUnlock()
 	}
 
-	if all, _ := c.peerHasAllPieces(false); all {
+	if all, _ := c.peerHasAllPieces(false, true); all {
 		isEmpty := c.t._pendingPieces.IsEmpty()
 
 		return !c.t.haveAllPieces(false, true) && !isEmpty
@@ -1066,7 +1066,7 @@ func (cn *Peer) newPeerPieces(lock bool, lockTorrent bool) (ret *roaring.Bitmap)
 		ret = cn.peerPieces(false).Clone()
 	}()
 
-	if all, _ := cn.peerHasAllPieces(lock); all {
+	if all, _ := cn.peerHasAllPieces(lock, true); all {
 		if cn.t.haveInfo(true) {
 			ret.AddRange(0, bitmap.BitRange(cn.t.numPieces(true)))
 		} else {

--- a/peer.go
+++ b/peer.go
@@ -28,7 +28,7 @@ type (
 	Peer struct {
 		// First to ensure 64-bit alignment for atomics. See #262.
 		_stats ConnStats
-		mu     mu //sync.RWMutex
+		mu     sync.RWMutex
 
 		t *Torrent
 

--- a/peer.go
+++ b/peer.go
@@ -929,7 +929,7 @@ func (c *Peer) peerHasWantedPieces(lock bool, lockTorrent bool) bool {
 	if all, _ := c.peerHasAllPieces(false); all {
 		isEmpty := c.t._pendingPieces.IsEmpty()
 
-		return !c.t.haveAllPieces(false) && !isEmpty
+		return !c.t.haveAllPieces(false, true) && !isEmpty
 	}
 	if !c.t.haveInfo(true) {
 		return !c.peerPieces(false).IsEmpty()

--- a/peerconn.go
+++ b/peerconn.go
@@ -147,7 +147,7 @@ func (l *PeerConn) hasPreferredNetworkOver(r *PeerConn) bool {
 	return ml.Less()
 }
 
-func (cn *PeerConn) peerHasAllPieces(lock bool) (all, known bool) {
+func (cn *PeerConn) peerHasAllPieces(lock bool, lockTorrentInfo bool) (all, known bool) {
 	if lock {
 		cn.mu.Lock()
 		defer cn.mu.Unlock()
@@ -157,11 +157,11 @@ func (cn *PeerConn) peerHasAllPieces(lock bool) (all, known bool) {
 		return true, true
 	}
 
-	if !cn.t.haveInfo(true) {
+	if !cn.t.haveInfo(lockTorrentInfo) {
 		return false, false
 	}
 
-	return cn._peerPieces.GetCardinality() == uint64(cn.t.numPieces(true)), true
+	return cn._peerPieces.GetCardinality() == uint64(cn.t.numPieces(lockTorrentInfo)), true
 }
 
 func (cn *PeerConn) onGotInfo(info *metainfo.Info, lock bool, lockTorrent bool) {

--- a/peerconn.go
+++ b/peerconn.go
@@ -270,19 +270,24 @@ func (cn *PeerConn) requestedMetadataPiece(index int) bool {
 	return index < len(cn.metadataRequests) && cn.metadataRequests[index]
 }
 
-func (cn *PeerConn) onPeerSentCancel(r Request) {
+func (cn *PeerConn) onPeerSentCancel(r Request, lock bool) {
+	if lock {
+		cn.mu.Lock()
+		defer cn.mu.Unlock()
+	}
+
 	if _, ok := cn.peerRequests[r]; !ok {
 		torrent.Add("unexpected cancels received", 1)
 		return
 	}
 	if cn.fastEnabled() {
-		cn.reject(r)
+		cn.reject(r, false)
 	} else {
 		delete(cn.peerRequests, r)
 	}
 }
 
-func (cn *PeerConn) choke(msg messageWriter) (more bool) {
+func (cn *PeerConn) choke(msg messageWriter, lock bool) (more bool) {
 	if cn.choking {
 		return true
 	}
@@ -291,19 +296,29 @@ func (cn *PeerConn) choke(msg messageWriter) (more bool) {
 		Type: pp.Choke,
 	}, true)
 	if !cn.fastEnabled() {
-		cn.deleteAllPeerRequests()
+		cn.deleteAllPeerRequests(lock)
 	}
 	return
 }
 
-func (cn *PeerConn) deleteAllPeerRequests() {
+func (cn *PeerConn) deleteAllPeerRequests(lock bool) {
+	if lock {
+		cn.mu.Lock()
+		defer cn.mu.Unlock()
+	}
+
 	for _, state := range cn.peerRequests {
 		state.allocReservation.Drop()
 	}
 	cn.peerRequests = nil
 }
 
-func (cn *PeerConn) unchoke(msg func(pp.Message, bool) bool) bool {
+func (cn *PeerConn) unchoke(msg func(pp.Message, bool) bool, lock bool) bool {
+	if lock {
+		cn.mu.Lock()
+		defer cn.mu.Unlock()
+	}
+
 	if !cn.choking {
 		return true
 	}
@@ -381,7 +396,7 @@ func (cn *PeerConn) fillWriteBuffer() {
 			return
 		}
 	}
-	cn.upload(write)
+	cn.upload(write, true)
 }
 
 func (cn *PeerConn) have(piece pieceIndex) {
@@ -625,12 +640,18 @@ func (c *PeerConn) fastEnabled() bool {
 	return c.PeerExtensionBytes.SupportsFast() && c.t.cl.config.Extensions.SupportsFast()
 }
 
-func (c *PeerConn) reject(r Request) {
+func (c *PeerConn) reject(r Request, lock bool) {
 	if !c.fastEnabled() {
 		panic("fast not enabled")
 	}
 	c.write(r.ToMsg(pp.Reject), true)
 	// It is possible to reject a request before it is added to peer requests due to being invalid.
+
+	if lock {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+	}
+
 	if state, ok := c.peerRequests[r]; ok {
 		state.allocReservation.Drop()
 		delete(c.peerRequests, r)
@@ -646,7 +667,12 @@ func (c *PeerConn) maximumPeerRequestChunkLength() (_ Option[int]) {
 }
 
 // startFetch is for testing purposes currently.
-func (c *PeerConn) onReadRequest(r Request, startFetch bool) error {
+func (c *PeerConn) onReadRequest(r Request, startFetch bool, lock bool) error {
+	if lock {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+	}
+
 	requestedChunkLengths.Add(strconv.FormatUint(r.Length.Uint64(), 10), 1)
 	if _, ok := c.peerRequests[r]; ok {
 		torrent.Add("duplicate requests received", 1)
@@ -659,7 +685,7 @@ func (c *PeerConn) onReadRequest(r Request, startFetch bool) error {
 		torrent.Add("requests received while choking", 1)
 		if c.fastEnabled() {
 			torrent.Add("requests rejected while choking", 1)
-			c.reject(r)
+			c.reject(r, false)
 		}
 		return nil
 	}
@@ -667,7 +693,7 @@ func (c *PeerConn) onReadRequest(r Request, startFetch bool) error {
 	if len(c.peerRequests) >= localClientReqq {
 		torrent.Add("requests received while queue full", 1)
 		if c.fastEnabled() {
-			c.reject(r)
+			c.reject(r, false)
 		}
 		// BEP 6 says we may close here if we choose.
 		return nil
@@ -676,7 +702,7 @@ func (c *PeerConn) onReadRequest(r Request, startFetch bool) error {
 		err := fmt.Errorf("peer requested chunk too long (%v)", r.Length)
 		c.logger.Levelf(log.Warning, err.Error())
 		if c.fastEnabled() {
-			c.reject(r)
+			c.reject(r, false)
 			return nil
 		} else {
 			return err
@@ -719,7 +745,7 @@ func (c *PeerConn) peerRequestDataReader(r Request, prs *peerRequestState) {
 	}
 	b, err := c.readPeerRequestData(r)
 	if err != nil {
-		c.peerRequestDataReadFailed(err, r, true)
+		c.peerRequestDataReadFailed(err, r, true, true)
 	} else {
 		if b == nil {
 			panic("data must be non-nil to trigger send")
@@ -733,7 +759,7 @@ func (c *PeerConn) peerRequestDataReader(r Request, prs *peerRequestState) {
 
 // If this is maintained correctly, we might be able to support optional synchronous reading for
 // chunk sending, the way it used to work.
-func (c *PeerConn) peerRequestDataReadFailed(err error, r Request, lockTorrent bool) {
+func (c *PeerConn) peerRequestDataReadFailed(err error, r Request, lock bool, lockTorrent bool) {
 	if lockTorrent {
 		c.t.mu.Lock()
 		defer c.t.mu.Unlock()
@@ -764,7 +790,7 @@ func (c *PeerConn) peerRequestDataReadFailed(err error, r Request, lockTorrent b
 	// if they kick us for breaking protocol, on reconnect we will be compliant again (at least
 	// initially).
 	if c.fastEnabled() {
-		c.reject(r)
+		c.reject(r, lock)
 	} else {
 		if c.choking {
 			// If fast isn't enabled, I think we would have wiped all peer requests when we last
@@ -773,7 +799,7 @@ func (c *PeerConn) peerRequestDataReadFailed(err error, r Request, lockTorrent b
 			c.logger.WithDefaultLevel(log.Warning).Printf("already choking peer, requests might not be rejected correctly")
 		}
 		// Choking a non-fast peer should cause them to flush all their requests.
-		c.choke(c.write)
+		c.choke(c.write, lock)
 	}
 }
 
@@ -935,7 +961,7 @@ func (c *PeerConn) mainReadLoop() (err error) {
 			err = c.peerSentBitfield(msg.Bitfield, true, true)
 		case pp.Request:
 			r := newRequestFromMessage(&msg)
-			err = c.onReadRequest(r, true)
+			err = c.onReadRequest(r, true, true)
 			if err != nil {
 				err = fmt.Errorf("on reading request %v: %w", r, err)
 			}
@@ -950,7 +976,7 @@ func (c *PeerConn) mainReadLoop() (err error) {
 			}
 		case pp.Cancel:
 			req := newRequestFromMessage(&msg)
-			c.onPeerSentCancel(req)
+			c.onPeerSentCancel(req, true)
 		case pp.Port:
 			ipa, ok := tryIpPortFromNetAddr(c.RemoteAddr)
 			if !ok {
@@ -1150,22 +1176,41 @@ func (c *PeerConn) setRetryUploadTimer(delay time.Duration) {
 }
 
 // Also handles choking and unchoking of the remote peer.
-func (c *PeerConn) upload(msg func(pp.Message, bool) bool) bool {
+func (c *PeerConn) upload(msg func(pp.Message, bool) bool, lock bool) bool {
 	// Breaking or completing this loop means we don't want to upload to the peer anymore, and we
 	// choke them.
 another:
 	for c.uploadAllowed() {
 		// We want to upload to the peer.
-		if !c.unchoke(msg) {
+		if !c.unchoke(msg, lock) {
 			return false
 		}
-		for r, state := range c.peerRequests {
-			if state.data == nil {
+
+		type peerRequest struct {
+			Request
+			state *peerRequestState
+		}
+
+		var peerRequests []peerRequest
+
+		func() {
+			if lock {
+				c.mu.RLock()
+				defer c.mu.RUnlock()
+			}
+			peerRequests = make([]peerRequest, 0, len(c.peerRequests))
+			for r, state := range c.peerRequests {
+				peerRequests = append(peerRequests, peerRequest{r, state})
+			}
+		}()
+
+		for _, peerRequest := range peerRequests {
+			if peerRequest.state.data == nil {
 				continue
 			}
-			res := c.t.cl.config.UploadRateLimiter.ReserveN(time.Now(), int(r.Length))
+			res := c.t.cl.config.UploadRateLimiter.ReserveN(time.Now(), int(peerRequest.Length))
 			if !res.OK() {
-				panic(fmt.Sprintf("upload rate limiter burst size < %d", r.Length))
+				panic(fmt.Sprintf("upload rate limiter burst size < %d", peerRequest.Length))
 			}
 			delay := res.Delay()
 			if delay > 0 {
@@ -1174,8 +1219,16 @@ another:
 				// Hard to say what to return here.
 				return true
 			}
-			more := c.sendChunk(r, msg, state)
-			delete(c.peerRequests, r)
+			more := c.sendChunk(peerRequest.Request, msg, peerRequest.state)
+
+			func() {
+				if lock {
+					c.mu.Lock()
+					defer c.mu.Unlock()
+				}
+				delete(c.peerRequests, peerRequest.Request)
+			}()
+
 			if !more {
 				return false
 			}
@@ -1183,7 +1236,7 @@ another:
 		}
 		return true
 	}
-	return c.choke(msg)
+	return c.choke(msg, lock)
 }
 
 func (cn *PeerConn) drop(lock bool, lockTorrent bool) {

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -377,18 +377,18 @@ func TestReceiveLargeRequest(t *testing.T) {
 	req := Request{}
 	req.Length = defaultChunkSize
 	c.Assert(pc.fastEnabled(), qt.IsTrue)
-	c.Check(pc.onReadRequest(req, false), qt.IsNil)
+	c.Check(pc.onReadRequest(req, false, true), qt.IsNil)
 	c.Check(pc.peerRequests, qt.HasLen, 1)
 	req.Length = 2 << 20
-	c.Check(pc.onReadRequest(req, false), qt.IsNil)
+	c.Check(pc.onReadRequest(req, false, true), qt.IsNil)
 	c.Check(pc.peerRequests, qt.HasLen, 2)
 	pc.peerRequests = nil
 	pc.t.cl.config.UploadRateLimiter = rate.NewLimiter(1, defaultChunkSize)
 	req.Length = defaultChunkSize
-	c.Check(pc.onReadRequest(req, false), qt.IsNil)
+	c.Check(pc.onReadRequest(req, false, true), qt.IsNil)
 	c.Check(pc.peerRequests, qt.HasLen, 1)
 	req.Length = 2 << 20
-	c.Check(pc.onReadRequest(req, false), qt.IsNil)
+	c.Check(pc.onReadRequest(req, false, true), qt.IsNil)
 	c.Check(pc.messageWriter.writeBuffer.Len(), qt.Equals, 17)
 }
 

--- a/peerconn_test.go
+++ b/peerconn_test.go
@@ -290,7 +290,7 @@ func TestHaveAllThenBitfield(t *testing.T) {
 		Pieces:      make([]byte, pieceHash.Size()*7),
 	}, true), qt.IsNil)
 	pc.t.onSetInfo(true, true)
-	c.Check(tt.numPieces(), qt.Equals, 7)
+	c.Check(tt.numPieces(true), qt.Equals, 7)
 	c.Check(tt.pieceAvailabilityRuns(true), qt.DeepEquals, []pieceAvailabilityRun{
 		// The last element of the bitfield is irrelevant, as the Torrent actually only has 7
 		// pieces.

--- a/piece.go
+++ b/piece.go
@@ -217,16 +217,16 @@ func (p *Piece) queuedForHash(lock bool) bool {
 
 func (p *Piece) torrentBeginOffset(lock bool) int64 {
 	if lock {
-		p.t.imu.Lock()
-		defer p.t.imu.Unlock()
+		p.t.imu.RLock()
+		defer p.t.imu.RUnlock()
 	}
 	return int64(p.index) * p.t.info.PieceLength
 }
 
 func (p *Piece) torrentEndOffset(lock bool) int64 {
 	if lock {
-		p.t.imu.Lock()
-		defer p.t.imu.Unlock()
+		p.t.imu.RLock()
+		defer p.t.imu.RUnlock()
 	}
 	return p.torrentBeginOffset(false) + int64(p.length(false))
 }

--- a/piece.go
+++ b/piece.go
@@ -255,7 +255,7 @@ func (p *Piece) purePriority(lockTorrent bool) (ret piecePriority) {
 func (p *Piece) uncachedPriority(lockTorrent bool) (ret piecePriority) {
 	p.mu.RLock()
 	processing := p.hashing || p.marking
-	p.mu.Unlock()
+	p.mu.RUnlock()
 
 	if lockTorrent {
 		p.t.mu.RLock()

--- a/piece.go
+++ b/piece.go
@@ -144,8 +144,8 @@ func (p *Piece) chunkIndexDirty(chunk chunkIndexType, lockTorrent bool) bool {
 	return p.t.dirtyChunks.Contains(p.requestIndexOffset(false) + chunk)
 }
 
-func (p *Piece) chunkIndexSpec(chunk chunkIndexType) ChunkSpec {
-	return chunkIndexSpec(pp.Integer(chunk), p.length(true), p.chunkSize())
+func (p *Piece) chunkIndexSpec(chunk chunkIndexType, lockInfo bool) ChunkSpec {
+	return chunkIndexSpec(pp.Integer(chunk), p.length(lockInfo), p.chunkSize())
 }
 
 func (p *Piece) numDirtyBytes(lockTorrent bool, lockInfo bool) (ret pp.Integer) {
@@ -162,7 +162,7 @@ func (p *Piece) numDirtyBytes(lockTorrent bool, lockInfo bool) (ret pp.Integer) 
 	numRegularDirtyChunks := p.numDirtyChunks(false)
 	if p.chunkIndexDirty(p.numChunks(lockInfo)-1, false) {
 		numRegularDirtyChunks--
-		ret += p.chunkIndexSpec(p.lastChunkIndex(lockInfo)).Length
+		ret += p.chunkIndexSpec(p.lastChunkIndex(lockInfo), lockInfo).Length
 	}
 	ret += pp.Integer(numRegularDirtyChunks) * p.chunkSize()
 	return

--- a/piece.go
+++ b/piece.go
@@ -162,7 +162,7 @@ func (p *Piece) numDirtyBytes(lockTorrent bool, lockInfo bool) (ret pp.Integer) 
 	numRegularDirtyChunks := p.numDirtyChunks(false)
 	if p.chunkIndexDirty(p.numChunks(lockInfo)-1, false) {
 		numRegularDirtyChunks--
-		ret += p.chunkIndexSpec(p.lastChunkIndex()).Length
+		ret += p.chunkIndexSpec(p.lastChunkIndex(lockInfo)).Length
 	}
 	ret += pp.Integer(numRegularDirtyChunks) * p.chunkSize()
 	return
@@ -176,8 +176,8 @@ func (p *Piece) chunkSize() pp.Integer {
 	return p.t.chunkSize
 }
 
-func (p *Piece) lastChunkIndex() chunkIndexType {
-	return p.numChunks(true) - 1
+func (p *Piece) lastChunkIndex(lockInfo bool) chunkIndexType {
+	return p.numChunks(lockInfo) - 1
 }
 
 func (p *Piece) bytesLeft() (ret pp.Integer) {

--- a/request-strategy-impls.go
+++ b/request-strategy-impls.go
@@ -93,6 +93,10 @@ func (r requestStrategyTorrent) RUnlock() {
 	r.t.mu.RUnlock()
 }
 
+func (r requestStrategyTorrent) NumPieces() pieceIndex {
+	return r.t.NumPieces()
+}
+
 var _ request_strategy.Torrent = requestStrategyTorrent{}
 
 type requestStrategyPiece Piece
@@ -102,7 +106,7 @@ func (r *requestStrategyPiece) Request(lockTorrent bool) bool {
 }
 
 func (r *requestStrategyPiece) NumPendingChunks(lockTorrent bool) int {
-	return int(r.t.pieceNumPendingChunks(r.index, lockTorrent))
+	return int(r.t.pieceNumPendingChunks((*Piece)(r), lockTorrent))
 }
 
 var _ request_strategy.Piece = (*requestStrategyPiece)(nil)

--- a/request-strategy-impls_test.go
+++ b/request-strategy-impls_test.go
@@ -101,7 +101,7 @@ func BenchmarkRequestStrategy(b *testing.B) {
 	c.Assert(tor.storage, qt.IsNotNil)
 	const chunkSize = defaultChunkSize
 	peer.onPeerHasAllPiecesNoTriggers(true, true)
-	for i := 0; i < tor.numPieces(); i++ {
+	for i := 0; i < tor.numPieces(true); i++ {
 		tor.pieces[i].priority.Raise(PiecePriorityNormal)
 		tor.updatePiecePriorityNoTriggers(i, true)
 	}

--- a/request-strategy/torrent.go
+++ b/request-strategy/torrent.go
@@ -3,6 +3,7 @@ package requestStrategy
 type Torrent interface {
 	Piece(int, bool) Piece
 	PieceLength() int64
+	NumPieces() int
 	GetPieceRequestOrder() *PieceRequestOrder
 	RLock()
 	RUnlock()

--- a/requesting.go
+++ b/requesting.go
@@ -198,7 +198,7 @@ func (p *Peer) getDesiredRequestState(debug bool, lock bool, lockTorrent bool) (
 	}
 
 	// having this here ensures lock serialization
-	all, known := p.peerHasAllPieces(lock)
+	all, known := p.peerHasAllPieces(lock, true)
 	peerHasAllPieces := all && known
 
 	if lock {
@@ -361,7 +361,7 @@ func (p *Peer) allowSendNotInterested(lock bool, lockTorrent bool) bool {
 	if p.t.haveAllPieces(lockTorrent, true) {
 		return true
 	}
-	all, known := p.peerHasAllPieces(lock)
+	all, known := p.peerHasAllPieces(lock, true)
 	if all || !known {
 		return false
 	}

--- a/requesting.go
+++ b/requesting.go
@@ -358,7 +358,7 @@ func (t *Torrent) cacheNextRequestIndexesForReuse(slice []RequestIndex, lock boo
 // currently need anything.
 func (p *Peer) allowSendNotInterested(lock bool, lockTorrent bool) bool {
 	// Except for caching, we're not likely to lose pieces very soon.
-	if p.t.haveAllPieces(lockTorrent) {
+	if p.t.haveAllPieces(lockTorrent, true) {
 		return true
 	}
 	all, known := p.peerHasAllPieces(lock)

--- a/requesting.go
+++ b/requesting.go
@@ -175,7 +175,7 @@ func (p *Peer) getDesiredRequestState(debug bool, lock bool, lockTorrent bool) (
 		t.mu.RLock()
 	}
 
-	if !t.haveInfo(false) || t.closed.IsSet() || t.dataDownloadDisallowed.Bool() {
+	if !t.haveInfo(true) || t.closed.IsSet() || t.dataDownloadDisallowed.Bool() {
 		if lockTorrent {
 			t.mu.RUnlock()
 		}
@@ -198,7 +198,7 @@ func (p *Peer) getDesiredRequestState(debug bool, lock bool, lockTorrent bool) (
 	}
 
 	// having this here ensures lock serialization
-	all, known := p.peerHasAllPieces(lock, lockTorrent)
+	all, known := p.peerHasAllPieces(lock)
 	peerHasAllPieces := all && known
 
 	if lock {
@@ -361,7 +361,7 @@ func (p *Peer) allowSendNotInterested(lock bool, lockTorrent bool) bool {
 	if p.t.haveAllPieces(lockTorrent) {
 		return true
 	}
-	all, known := p.peerHasAllPieces(lock, lockTorrent)
+	all, known := p.peerHasAllPieces(lock)
 	if all || !known {
 		return false
 	}

--- a/t.go
+++ b/t.go
@@ -75,7 +75,7 @@ func (t *Torrent) PieceState(piece pieceIndex) (ps PieceState) {
 // The number of pieces in the torrent. This requires that the info has been
 // obtained first.
 func (t *Torrent) NumPieces() pieceIndex {
-	return t.numPieces()
+	return t.numPieces(true)
 }
 
 // Get missing bytes count for specific piece.
@@ -239,7 +239,7 @@ func (t *Torrent) AddPeers(pp []PeerInfo) (n int) {
 // Marks the entire torrent for download. Requires the info first, see
 // GotInfo. Sets piece priorities for historical reasons.
 func (t *Torrent) DownloadAll() {
-	t.DownloadPieces(0, t.numPieces())
+	t.DownloadPieces(0, t.numPieces(true))
 }
 
 func (t *Torrent) String() string {

--- a/torrent-piece-request-order.go
+++ b/torrent-piece-request-order.go
@@ -40,7 +40,7 @@ func (t *Torrent) deletePieceRequestOrder() {
 	cpro := t.cl.pieceRequestOrder
 	key := t.clientPieceRequestOrderKey()
 	pro := cpro[key]
-	for i := 0; i < t.numPieces(); i++ {
+	for i := 0; i < t.numPieces(true); i++ {
 		pro.Delete(t.pieceRequestOrderKey(i))
 	}
 	if pro.Len() == 0 {
@@ -64,7 +64,7 @@ func (t *Torrent) initPieceRequestOrder(lockClient bool) {
 
 	cpro := t.cl.pieceRequestOrder
 	if cpro[key] == nil {
-		cpro[key] = request_strategy.NewPieceOrder(request_strategy.NewAjwernerBtree(), t.numPieces())
+		cpro[key] = request_strategy.NewPieceOrder(request_strategy.NewAjwernerBtree(), t.numPieces(true))
 	}
 	t.clientPieceRequestOrder = cpro[key]
 }

--- a/torrent.go
+++ b/torrent.go
@@ -204,7 +204,7 @@ type Torrent struct {
 
 	// Name used if the info name isn't available. Should be cleared when the
 	// Info does become available.
-	mu          deadlock.RWMutex // mu //sync.RWMutex
+	mu          sync.RWMutex
 	imu         sync.RWMutex
 	displayName string
 

--- a/torrent.go
+++ b/torrent.go
@@ -3283,6 +3283,9 @@ func (t *Torrent) AddWebSeeds(urls []string, opts ...AddWebSeedsOpt) {
 }
 
 func (t *Torrent) addWebSeed(url string, lock bool, opts ...AddWebSeedsOpt) {
+	start := time.Now()
+	fmt.Println("AWS", url, t.info)
+	defer fmt.Println("AWS", url, t.info, "DONE", time.Since(start))
 	if lock {
 		t.mu.Lock()
 		defer t.mu.Unlock()

--- a/torrent.go
+++ b/torrent.go
@@ -3430,7 +3430,7 @@ func (t *Torrent) requestIndexToRequest(ri RequestIndex, lock bool) Request {
 	index := t.pieceIndexOfRequestIndex(ri, lock)
 	return Request{
 		pp.Integer(index),
-		t.piece(index, lock).chunkIndexSpec(ri % t.chunksPerRegularPiece(lock)),
+		t.piece(index, lock).chunkIndexSpec(ri%t.chunksPerRegularPiece(lock), true),
 	}
 }
 

--- a/torrent.go
+++ b/torrent.go
@@ -32,6 +32,7 @@ import (
 	"github.com/anacrolix/multiless"
 	"github.com/anacrolix/sync"
 	"github.com/pion/datachannel"
+	"github.com/sasha-s/go-deadlock"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 
@@ -49,9 +50,9 @@ import (
 	typedRoaring "github.com/anacrolix/torrent/typed-roaring"
 	"github.com/anacrolix/torrent/webseed"
 	"github.com/anacrolix/torrent/webtorrent"
+	stack2 "github.com/go-stack/stack"
 )
 
-/*
 func stack(skip int) string {
 	return stack2.Trace().TrimBelow(stack2.Caller(skip)).String()
 }
@@ -127,7 +128,6 @@ func (m *mu) Unlock() {
 	m.RWMutex.Unlock()
 	//fmt.Println("LUN", m.lc) //, string(dbg.Stack()))
 }
-*/
 
 // Maintains state of torrent within a Client. Many methods should not be called before the info is
 // available, see .Info and .GotInfo.
@@ -200,7 +200,7 @@ type Torrent struct {
 
 	// Name used if the info name isn't available. Should be cleared when the
 	// Info does become available.
-	mu          sync.RWMutex
+	mu          mu //sync.RWMutex
 	displayName string
 
 	// The bencoded bytes of the info dict. This is actively manipulated if

--- a/torrent.go
+++ b/torrent.go
@@ -57,6 +57,10 @@ func stack(skip int) string {
 	return stack2.Trace().TrimBelow(stack2.Caller(skip)).String()
 }
 
+func init() {
+	deadlock.Opts.DeadlockTimeout = 3 * time.Minute
+}
+
 type mu struct {
 	deadlock.RWMutex
 	rlc        atomic.Int32

--- a/torrent.go
+++ b/torrent.go
@@ -951,7 +951,7 @@ func (t *Torrent) writeStatus(w io.Writer) {
 		}
 		fmt.Fprintf(w, "Piece length: %s\n",
 			func() string {
-				if t.haveInfo(true) {
+				if t.haveInfo(false) {
 					return fmt.Sprintf("%v (%v chunks)",
 						t.usualPieceSize(false),
 						float64(t.usualPieceSize(false))/float64(t.chunkSize))

--- a/torrent.go
+++ b/torrent.go
@@ -3283,9 +3283,6 @@ func (t *Torrent) AddWebSeeds(urls []string, opts ...AddWebSeedsOpt) {
 }
 
 func (t *Torrent) addWebSeed(url string, lock bool, opts ...AddWebSeedsOpt) {
-	start := time.Now()
-	fmt.Println("AWS", url, t.info != nil)
-	defer fmt.Println("AWS", url, t.info != nil, "DONE", time.Since(start))
 	if lock {
 		t.mu.Lock()
 		defer t.mu.Unlock()

--- a/torrent.go
+++ b/torrent.go
@@ -3284,8 +3284,8 @@ func (t *Torrent) AddWebSeeds(urls []string, opts ...AddWebSeedsOpt) {
 
 func (t *Torrent) addWebSeed(url string, lock bool, opts ...AddWebSeedsOpt) {
 	start := time.Now()
-	fmt.Println("AWS", url, t.info)
-	defer fmt.Println("AWS", url, t.info, "DONE", time.Since(start))
+	fmt.Println("AWS", url, t.info != nil)
+	defer fmt.Println("AWS", url, t.info != nil, "DONE", time.Since(start))
 	if lock {
 		t.mu.Lock()
 		defer t.mu.Unlock()

--- a/torrent.go
+++ b/torrent.go
@@ -205,7 +205,7 @@ type Torrent struct {
 	// Name used if the info name isn't available. Should be cleared when the
 	// Info does become available.
 	mu          deadlock.RWMutex // mu //sync.RWMutex
-	imu         deadlock.RWMutex //sync.RWMutex
+	imu         sync.RWMutex
 	displayName string
 
 	// The bencoded bytes of the info dict. This is actively manipulated if

--- a/torrent.go
+++ b/torrent.go
@@ -2810,21 +2810,27 @@ func (t *Torrent) tryCreateMorePieceHashers(lock bool) {
 		activePieceHashes < t.cl.config.PieceHashersPerTorrent &&
 		activePieceHashes < t.numPieces() &&
 		activePieceHashes < int(t.numQueuedForHash(lock)) &&
-		t.tryCreatePieceHasher() {
+		t.tryCreatePieceHasher(lock) {
 		activePieceHashes = int(t.activePieceHashes.Load())
 	}
 }
 
-func (t *Torrent) tryCreatePieceHasher() bool {
+func (t *Torrent) tryCreatePieceHasher(lock bool) bool {
 	if t.storage == nil {
 		return false
 	}
 
-	t.mu.RLock()
+	if lock {
+		t.mu.RLock()
+	}
+
 	activePieceHashes := &t.activePieceHashes
 	hashing := &t.hashing
 	storageLock := &t.storageLock
-	t.mu.RUnlock()
+
+	if lock {
+		t.mu.RUnlock()
+	}
 
 	activePieceHashes.Add(1)
 

--- a/torrent.go
+++ b/torrent.go
@@ -1347,7 +1347,7 @@ func (t *Torrent) haveAllPieces(lock bool) bool {
 		t.mu.RLock()
 		defer t.mu.RUnlock()
 	}
-	return t._completedPieces.GetCardinality() == bitmap.BitRange(t.numPieces())
+	return t._completedPieces.GetCardinality() == bitmap.BitRange(t.info.NumPieces())
 }
 
 func (t *Torrent) havePiece(index pieceIndex, lock bool) bool {

--- a/torrent.go
+++ b/torrent.go
@@ -1067,33 +1067,6 @@ func (t *Torrent) haveInfo(lock bool) bool {
 	return t.info != nil
 }
 
-// Returns a run-time generated MetaInfo that includes the info bytes and
-// announce-list as currently known to the client.
-func (t *Torrent) newMetaInfo() metainfo.MetaInfo {
-	t.imu.RLock()
-	defer t.imu.RUnlock()
-	return metainfo.MetaInfo{
-		CreationDate: time.Now().Unix(),
-		Comment:      "dynamic metainfo from client",
-		CreatedBy:    "go.torrent",
-		AnnounceList: t.metainfo.UpvertedAnnounceList().Clone(),
-		InfoBytes: func() []byte {
-			if t.haveInfo(false) {
-				return t.metadataBytes
-			} else {
-				return nil
-			}
-		}(),
-		UrlList: func() []string {
-			ret := make([]string, 0, len(t.webSeeds))
-			for url := range t.webSeeds {
-				ret = append(ret, url)
-			}
-			return ret
-		}(),
-	}
-}
-
 // Returns a count of bytes that are not complete in storage, and not pending being written to
 // storage. This value is from the perspective of the download manager, and may not agree with the
 // actual state in storage. If you want read data synchronously you should use a Reader. See

--- a/torrent.go
+++ b/torrent.go
@@ -617,7 +617,7 @@ func (t *Torrent) setInfo(info *metainfo.Info, lock bool) error {
 	}
 
 	t.imu.Lock()
-	defer t.imu.RUnlock()
+	defer t.imu.Unlock()
 
 	t.info = info
 	t.displayName = "" // Save a few bytes lol.

--- a/torrent.go
+++ b/torrent.go
@@ -1019,7 +1019,7 @@ func (t *Torrent) writeStatus(w io.Writer) {
 
 		fmt.Fprintf(w, "DHT Announces: %d\n", t.numDHTAnnounces)
 
-		dumpStats(w, t.stats(false))
+		dumpStats(w, t.stats(false, false))
 	}()
 
 	fmt.Fprintf(w, "webseeds:\n")
@@ -1380,7 +1380,7 @@ func (t *Torrent) maybeDropMutuallyCompletePeer(
 	if !t.haveAllPieces(lock, true) {
 		return
 	}
-	if all, known := p.peerHasAllPieces(lockPeer); !(known && all) {
+	if all, known := p.peerHasAllPieces(lockPeer, true); !(known && all) {
 		return
 	}
 	if p.useful(lockPeer, lock) {
@@ -2429,10 +2429,10 @@ func (t *Torrent) addPeers(peers []PeerInfo, lock bool) (added int) {
 // The returned TorrentStats may require alignment in memory. See
 // https://github.com/anacrolix/torrent/issues/383.
 func (t *Torrent) Stats() TorrentStats {
-	return t.stats(true)
+	return t.stats(true, true)
 }
 
-func (t *Torrent) stats(lock bool) (ret TorrentStats) {
+func (t *Torrent) stats(lock bool, lockInfo bool) (ret TorrentStats) {
 	if lock {
 		t.mu.RLock()
 		defer t.mu.RUnlock()
@@ -2444,7 +2444,7 @@ func (t *Torrent) stats(lock bool) (ret TorrentStats) {
 	ret.TotalPeers = t.numTotalPeers(false)
 	ret.ConnectedSeeders = 0
 	for c := range t.conns {
-		if all, ok := c.peerHasAllPieces(true); all && ok {
+		if all, ok := c.peerHasAllPieces(true, lockInfo); all && ok {
 			ret.ConnectedSeeders++
 		}
 	}

--- a/torrent.go
+++ b/torrent.go
@@ -778,7 +778,7 @@ func (t *Torrent) name(lock bool) string {
 		defer t.imu.RUnlock()
 	}
 
-	if t.haveInfo(true) {
+	if t.haveInfo(false) {
 		return t.info.BestName()
 	}
 
@@ -936,7 +936,7 @@ func (t *Torrent) writeStatus(w io.Writer) {
 
 		fmt.Fprintf(w, "Infohash: %s\n", t.infoHash.HexString())
 		fmt.Fprintf(w, "Metadata length: %d\n", t.metadataSize(false))
-		if !t.haveInfo(true) {
+		if !t.haveInfo(false) {
 			fmt.Fprintf(w, "Metadata have: ")
 			for _, h := range t.metadataCompletedChunks {
 				fmt.Fprintf(w, "%c", func() rune {

--- a/torrent.go
+++ b/torrent.go
@@ -1538,13 +1538,17 @@ func (t *Torrent) publishPieceStateChange(piece pieceIndex, lock bool) {
 	p.mu.Unlock()
 }
 
-func (t *Torrent) pieceNumPendingChunks(piece pieceIndex, lock bool) pp.Integer {
-	if t.pieceComplete(piece, lock) {
+func (t *Torrent) pieceNumPendingChunks(piece *Piece, lock bool) pp.Integer {
+	if lock {
+		t.mu.RLock()
+		defer t.mu.RUnlock()
+	}
+
+	if t.pieceComplete(piece.index, false) {
 		return 0
 	}
 
-	p := t.piece(piece, lock)
-	return pp.Integer(t.pieceNumChunks(piece) - p.numDirtyChunks(lock))
+	return pp.Integer(t.pieceNumChunks(piece.index) - piece.numDirtyChunks(lock))
 }
 
 func (t *Torrent) pieceAllDirty(piece pieceIndex, lock bool) bool {

--- a/torrent.go
+++ b/torrent.go
@@ -3361,7 +3361,7 @@ func (t *Torrent) addWebSeed(url string, lock bool, opts ...AddWebSeedsOpt) {
 
 	t.imu.RLock()
 	info := t.info
-	defer t.imu.RUnlock()
+	t.imu.RUnlock()
 
 	if bandwidth := t.cl.config.DownloadRateLimiter.Limit(); bandwidth > 0 && info != nil {
 		if maxPieceRequests := int(bandwidth / rate.Limit(info.PieceLength)); maxPieceRequests > peerMaxRequests {

--- a/torrent.go
+++ b/torrent.go
@@ -2850,7 +2850,9 @@ func (t *Torrent) tryCreatePieceHasher(lock bool) bool {
 				t.mu.Lock()
 				defer t.mu.Unlock()
 				t.piecesQueuedForHash.Remove(bitmap.BitIndex(p.index))
+				p.mu.Lock()
 				p.hashing = true
+				p.mu.Unlock()
 				hashing.Add(1)
 				t.publishPieceStateChange(p.index, false)
 				t.updatePiecePriority(p.index, "Torrent.tryCreatePieceHasher", false)
@@ -2869,9 +2871,9 @@ func (t *Torrent) tryCreatePieceHasher(lock bool) bool {
 
 			storageLock.RUnlock()
 
-			t.mu.Lock()
+			p.mu.Lock()
 			p.hashing = false
-			t.mu.Unlock()
+			p.mu.Unlock()
 			hashing.Add(-1)
 
 			t.hashResults <- hashResult{p.index, correct, failedPeers, copyErr}

--- a/torrent_test.go
+++ b/torrent_test.go
@@ -94,17 +94,17 @@ func BenchmarkUpdatePiecePriorities(b *testing.B) {
 		Length:      pieceLength * numPieces,
 	}, true))
 	t.onSetInfo(true, true)
-	assert.EqualValues(b, 13410, t.numPieces())
+	assert.EqualValues(b, 13410, t.numPieces(true))
 	for i := 0; i < 7; i += 1 {
 		r := t.NewReader()
 		r.SetReadahead(32 << 20)
 		r.Seek(3500000, io.SeekStart)
 	}
 	assert.Len(b, t.readers, 7)
-	for i := 0; i < t.numPieces(); i += 3 {
+	for i := 0; i < t.numPieces(true); i += 3 {
 		t._completedPieces.Add(bitmap.BitIndex(i))
 	}
-	t.DownloadPieces(0, t.numPieces())
+	t.DownloadPieces(0, t.numPieces(true))
 	for i := 0; i < b.N; i += 1 {
 		t.updateAllPiecePriorities("", true)
 	}

--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -532,12 +532,6 @@ func (ws *webseedPeer) requestResultHandler(r Request, webseedRequest webseed.Re
 
 	err := result.Err
 
-	// the call may have been cancelled while it
-	// was in transit (via the chan)
-	if result.Ctx.Err() != nil {
-		err = result.Ctx.Err()
-	}
-
 	if err != nil {
 		switch {
 		case errors.Is(err, context.Canceled):
@@ -567,6 +561,13 @@ func (ws *webseedPeer) requestResultHandler(r Request, webseedRequest webseed.Re
 		}
 
 		return err
+	}
+
+	// the call may have been cancelled while it
+	// was in transit (via the chan)
+	if result.Ctx.Err() != nil {
+		ws.peer.remoteRejectedRequest(ws.peer.t.requestIndexFromRequest(r, true))
+		return result.Ctx.Err()
 	}
 
 	err = ws.peer.receiveChunk(&pp.Message{

--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -139,7 +139,7 @@ func (cn *webseedPeer) nominalMaxRequests(lock bool, lockTorrent bool) maxReques
 		defer cn.peer.mu.RUnlock()
 	}
 
-	activeRequestsPerPeer := cn.peer.bestPeerNumPieces(false, false) / maxInt(1, interestedPeers)
+	activeRequestsPerPeer := cn.peer.bestPeerNumPieces(false) / maxInt(1, interestedPeers)
 	return maxInt(1, minInt(cn.peer.PeerMaxRequests, maxInt(maxInt(8, activeRequestsPerPeer), cn.peer.peakRequests*2)))
 }
 
@@ -285,7 +285,7 @@ func (ws *webseedPeer) requester(i int) {
 				ws.peer.t.mu.RLock()
 				defer ws.peer.t.mu.RUnlock()
 
-				if ws.peer.t.haveInfo(false) && !(ws.peer.t.dataDownloadDisallowed.Bool() || ws.peer.t.Complete.Bool()) {
+				if ws.peer.t.haveInfo(true) && !(ws.peer.t.dataDownloadDisallowed.Bool() || ws.peer.t.Complete.Bool()) {
 					if ws.updateRequestor == nil {
 						if ws.unchokeTimerDuration == 0 {
 							// Don't wait for small files
@@ -345,7 +345,7 @@ func (ws *webseedPeer) logProgress(label string, lockTorrent bool) {
 		defer t.mu.RUnlock()
 	}
 
-	if !t.haveInfo(false) {
+	if !t.haveInfo(true) {
 		return
 	}
 
@@ -592,8 +592,8 @@ func (me *webseedPeer) peerPieces(lock bool) *roaring.Bitmap {
 	return &me.client.Pieces
 }
 
-func (cn *webseedPeer) peerHasAllPieces(lock bool, lockTorrent bool) (all, known bool) {
-	if !cn.peer.t.haveInfo(lockTorrent) {
+func (cn *webseedPeer) peerHasAllPieces(lock bool) (all, known bool) {
+	if !cn.peer.t.haveInfo(true) {
 		return true, false
 	}
 
@@ -602,5 +602,5 @@ func (cn *webseedPeer) peerHasAllPieces(lock bool, lockTorrent bool) (all, known
 		defer cn.peer.mu.RUnlock()
 	}
 
-	return cn.client.Pieces.GetCardinality() == uint64(cn.peer.t.numPieces()), true
+	return cn.client.Pieces.GetCardinality() == uint64(cn.peer.t.numPieces(true)), true
 }

--- a/webseed-peer.go
+++ b/webseed-peer.go
@@ -592,8 +592,8 @@ func (me *webseedPeer) peerPieces(lock bool) *roaring.Bitmap {
 	return &me.client.Pieces
 }
 
-func (cn *webseedPeer) peerHasAllPieces(lock bool) (all, known bool) {
-	if !cn.peer.t.haveInfo(true) {
+func (cn *webseedPeer) peerHasAllPieces(lock bool, lockTorrentInfo bool) (all, known bool) {
+	if !cn.peer.t.haveInfo(lockTorrentInfo) {
 		return true, false
 	}
 
@@ -602,5 +602,5 @@ func (cn *webseedPeer) peerHasAllPieces(lock bool) (all, known bool) {
 		defer cn.peer.mu.RUnlock()
 	}
 
-	return cn.client.Pieces.GetCardinality() == uint64(cn.peer.t.numPieces(true)), true
+	return cn.client.Pieces.GetCardinality() == uint64(cn.peer.t.numPieces(lockTorrentInfo)), true
 }

--- a/webseed/alloc_test.go
+++ b/webseed/alloc_test.go
@@ -1,9 +1,19 @@
 package webseed
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"testing"
 )
+
+type reader struct {
+	b *bytes.Buffer
+}
+
+func (r reader) Read(p []byte) (n int, err error) {
+	return r.b.Read(p)
+}
 
 func TestAlloc(t *testing.T) {
 	buff, err := bufPool.get(context.Background(), 2097152)
@@ -26,6 +36,30 @@ func TestAlloc(t *testing.T) {
 
 	input := [2097152]byte{}
 	buff.Write(input[:])
+
+	err = buff.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	source := reader{bytes.NewBuffer(nil)}
+
+	source.b.Write(input[:])
+
+	buff, err = bufPool.get(context.Background(), 2097152)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cap := buff.Cap()
+
+	io.Copy(buff, source)
+
+	if cap != buff.Cap() {
+		t.Fatal("Buffer resized in copy")
+	}
 
 	err = buff.Close()
 

--- a/webseed/alloc_test.go
+++ b/webseed/alloc_test.go
@@ -1,0 +1,35 @@
+package webseed
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAlloc(t *testing.T) {
+	buff, err := bufPool.get(context.Background(), 2097152)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = buff.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buff, err = bufPool.get(context.Background(), 2097152)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := [2097152]byte{}
+	buff.Write(input[:])
+
+	err = buff.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -153,12 +153,13 @@ func (ws *Client) NewRequest(r RequestSpec, limiter *rate.Limiter, receivingCoun
 			responseBodyWrapper: ws.ResponseBodyWrapper,
 		}
 		part.do = func() (*http.Response, io.ReadWriteCloser, error) {
+			fmt.Println("BP GET", e.Length)
 			buff, err := bufPool.get(ctx, e.Length)
 
 			if err != nil {
 				return nil, nil, err
 			}
-
+			fmt.Println("BP GOT", e.Length)
 			if err := limiter.WaitN(ctx, int(r.Length)); err != nil {
 				buff.Close()
 				return nil, nil, err

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -93,6 +93,7 @@ func (b buffer) Close() error {
 }
 
 func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
+	fmt.Println("GET", size)
 	if err := p.semMax.Acquire(ctx, size); err != nil {
 		return buffer{}, err
 	}
@@ -104,6 +105,7 @@ func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
 	if !ok {
 		pool = &sync.Pool{
 			New: func() interface{} {
+				fmt.Println("NEW", size)
 				return bytes.NewBuffer(make([]byte, 0, size))
 			},
 		}
@@ -118,7 +120,7 @@ func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
 
 func (p *pool) put(b *bytes.Buffer) {
 	size := int64(b.Cap())
-
+	fmt.Println("PUT", size)
 	p.mu.RLock()
 	pool, ok := p.buffers[size]
 	p.mu.RUnlock()

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -94,7 +94,6 @@ func (b buffer) Close() error {
 }
 
 func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
-	fmt.Println("GET", size)
 	if err := p.semMax.Acquire(ctx, size); err != nil {
 		return buffer{}, err
 	}
@@ -106,7 +105,6 @@ func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
 	if !ok {
 		pool = &sync.Pool{
 			New: func() interface{} {
-				fmt.Println("NEW", size)
 				// add one to capacity to avoid the buffer resizing when it
 				// is written to capacity
 				return bytes.NewBuffer(make([]byte, 0, size+1))
@@ -125,8 +123,6 @@ func (p *pool) put(b buffer) {
 	p.mu.RLock()
 	pool, ok := p.buffers[b.size]
 	p.mu.RUnlock()
-
-	fmt.Println("PUT", b.size, b.Len(), ok)
 
 	if ok {
 		b.Reset()

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -127,7 +127,7 @@ func (p *pool) put(b *bytes.Buffer) {
 	pool, ok := p.buffers[size]
 	p.mu.RUnlock()
 
-	fmt.Println("PUT", size, ok)
+	fmt.Println("PUT", size, b.Len(), ok)
 
 	if ok {
 		b.Reset()

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -120,7 +120,7 @@ func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
 
 func (p *pool) put(b *bytes.Buffer) {
 	size := int64(b.Cap())
-	fmt.Println("PUT", size)
+	fmt.Println("PUT", b.Cap(), b.Len())
 	p.mu.RLock()
 	pool, ok := p.buffers[size]
 	p.mu.RUnlock()

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -105,9 +105,9 @@ func (p *pool) get(ctx context.Context, size int64) (buffer, error) {
 	if !ok {
 		pool = &sync.Pool{
 			New: func() interface{} {
-				// add one to capacity to avoid the buffer resizing when it
-				// is written to capacity
-				return bytes.NewBuffer(make([]byte, 0, size+1))
+				// round to the nearest MinRead boundary otherwise io.Copy is going
+				// to result in the buffer getting grown ti around 2x its required size
+				return bytes.NewBuffer(make([]byte, 0, (size/bytes.MinRead+1)*bytes.MinRead))
 			},
 		}
 

--- a/webseed/client.go
+++ b/webseed/client.go
@@ -133,7 +133,7 @@ func (p *pool) put(b buffer) {
 
 var bufPool = &pool{
 	buffers: map[int64]*sync.Pool{},
-	semMax:  semaphore.NewWeighted(10_000_000_000), // TODO - needs config (should relate machine memory)
+	semMax:  semaphore.NewWeighted(5_000_000_000), // TODO - needs config (should relate machine memory)
 }
 
 func (ws *Client) NewRequest(r RequestSpec, limiter *rate.Limiter, receivingCounter *atomic.Int64) Request {

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -41,9 +41,6 @@ func worseConnInputFromPeer(p *PeerConn, opts worseConnLensOpts) *worseConnInput
 	}
 
 	if opts.lockPeer {
-		if p.mu.lc.Load() > 0 {
-			fmt.Println("WCI", "L", p.mu.locker, "N", p.mu.nextlocker)
-		}
 		p.mu.RLock()
 		defer p.mu.RUnlock()
 	}

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -47,7 +47,7 @@ func worseConnInputFromPeer(p *PeerConn, opts worseConnLensOpts) *worseConnInput
 
 	ret := worseConnInput{
 		Useful:             p.useful(false, false),
-		LastHelpful:        p.lastHelpful(false, false),
+		LastHelpful:        p.lastHelpful(false, p.t.seeding(false)),
 		CompletedHandshake: p.completedHandshake,
 		Pointer:            uintptr(unsafe.Pointer(p)),
 		GetPeerPriority:    p.peerPriority,

--- a/worse-conns.go
+++ b/worse-conns.go
@@ -41,6 +41,9 @@ func worseConnInputFromPeer(p *PeerConn, opts worseConnLensOpts) *worseConnInput
 	}
 
 	if opts.lockPeer {
+		if p.mu.lc.Load() > 0 {
+			fmt.Println("WCI", "L", p.mu.locker, "N", p.mu.nextlocker)
+		}
 		p.mu.RLock()
 		defer p.mu.RUnlock()
 	}


### PR DESCRIPTION
Webseed requests need to be throttled by both bandwidth and available memory otherwise we may issue more requests than the process can handle in return. 