### PR TITLE
Revert "fixed discover for new peers connection"

### DIFF
--- a/torrent.go
+++ b/torrent.go
@@ -2533,10 +2533,6 @@ func (t *Torrent) wantOutgoingConns(lock bool) bool {
 	conns := t.peerConnsAsSlice(lock)
 	defer conns.free()
 
-	if len(conns) < t.maxEstablishedConns {
-		return true
-	}
-
 	numOutgoingConns := conns.numOutgoingConns()
 	numIncomingConns := len(conns) - numOutgoingConns
 


### PR DESCRIPTION
Reverts erigontech/torrent#31 as Looks like it introduce issues which I don't want to have at release branch